### PR TITLE
allow annotation processor to run via an other apt

### DIFF
--- a/src/core/lombok/core/AnnotationProcessor.java
+++ b/src/core/lombok/core/AnnotationProcessor.java
@@ -163,7 +163,7 @@ public class AnnotationProcessor extends AbstractProcessor {
 		
 		for (ProcessorDescriptor proc : active) proc.process(annotations, roundEnv);
 		
-		return false;
+		return true;
 	}
 	
 	/**


### PR DESCRIPTION
Hi,

This change indicates to the java compiler that current annotation processor has altering files and he should take care about that. 
This is very usefull when you want to use lombok with another apt (like http://mapstruct.org/)